### PR TITLE
update: Dockerfile optimized & reduced build layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine:3.13
 LABEL maintainer="Asif Mohammad Mollah <https://mrasif.in>"
-RUN apk update
-RUN apk add curl ca-certificates
+RUN apk --no-cache add curl ca-certificates
 WORKDIR /script
 COPY ./script.sh /script/
 COPY ./curlrc /script/.curlrc


### PR DESCRIPTION
reduced 2M for the image.


Current,
```log
REPOSITORY      TAG       IMAGE ID       CREATED         SIZE
script-runner   latest    770a19bf7490   8 minutes ago   7.71MB
```
Old,
```log
REPOSITORY                     TAG       IMAGE ID       CREATED         SIZE
techthinkerorg/script-runner   latest    db34d7cd3f86   3 weeks ago     9.69MB
```